### PR TITLE
Increase TLD size on Link Filter

### DIFF
--- a/src/events/message.js
+++ b/src/events/message.js
@@ -38,7 +38,7 @@ module.exports.run = ({ client, serverInfo, message, args, sql, config, sendEmbe
         if (!message.member.isCH && !message.member.roles.has(serverInfo.roles.linksFiles)) {
             if (!(config.permits[message.author.id] && config.permits[message.author.id].channel === message.channel.id && config.permits[message.author.id].until > new Date().getTime())) {
                 if (!config.whitelistedLinksChannel.includes(message.channel.id)) {
-                    let matches = message.content.match(new RegExp(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig));
+                    let matches = message.content.match(new RegExp(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,12}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig));
                     let filtered = matches ? matches.filter(m => {
                         if (m.endsWith("discord.gg/alphaconsole")  ||
                             m.includes("imgur.com") ||


### PR DESCRIPTION
![image](https://puu.sh/CWZ5r/af954e9920.png)
_Blue highlight = triggered the regex
[Page for above](https://regexr.com/49ri2)_

The existing Regex for the link is good, however there are some TLDs that will be completely ignored by this expression allowing users to post links with long enough TLDs.
The average TLD is around 6 (likely for why this regex used it) but it you want to go full overkill, some TLDs you can buy are around 12 chars long, with 24 being the max (Although this is Japanese characters or something).
The image shows a few examples of some of the URLs I found with `download`, `computer` and `technology` being more likely to be used on a server. 

Little test script.
```
var URL = "http://www.alphaconsole.download"
let matches = url.match(new RegExp(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig));
// Currently using the default 6, but edit with 12 to show that it won't popup with the delete message. 
let filtered = matches ? matches.filter(m => {
	if (m.endsWith("discord.gg/alphaconsole")  || m.includes("imgur.com") || m.includes("reddit.com") || m.includes("gyazo.com") ||
 m.includes("prntscr.com"))
		return false
	else
		return true
}) : null;

if (filtered && filtered[0]) {
	console.log("MESSAGE DELETED");
}
```
Change the URL at the top / the regex with the higher TLD count to see it work