### PR TITLE
Adds Count of Mute/Warn/Kick/Bans to the top

### DIFF
--- a/src/cmds/check.js
+++ b/src/cmds/check.js
@@ -38,10 +38,10 @@ module.exports = {
                 .setAuthor("Cases check", client.user.displayAvatarURL({ format: "png" }))
                 .setColor([255, 255, 0])
                 .setThumbnail("http://www.pngmart.com/files/5/Snow-PNG-Transparent-Image.png")
-                .addField("Mutes", mutes.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : mutes.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
-                .addField("Warnings", warns.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : warns.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
-                .addField("Kicks", kicks.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : kicks.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
-                .addField("Bans", bans.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : bans.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
+                .addField(`Mutes (${mutes.size})`, mutes.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : mutes.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
+                .addField(`Warnings (${warns.size})`, warns.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : warns.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
+                .addField(`Kicks (${kicks.size})`, kicks.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : kicks.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
+                .addField(`Bans (${bans.size})`, bans.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n") === "" ? "Nothing found" : bans.map(c => `\`${c.ID}.\` ${c.Reason}`).join("\n").substring(0, 245), true)
             message.channel.send(embed);
         })
 


### PR DESCRIPTION
One thing to note is that I'm assuming that mutes,warns,kick,bans are all maps that will allow for the `MAP.size`.
If it's empty it will indeed still provide back 0.

Additionally you could reduce load on bot by using size within check within the (CONDITION) ? "True" : "False".

Example (not actually tested)
![image](https://puu.sh/D0O1j/ecd1ca0364.png)